### PR TITLE
Added QB SOUND keyword

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tools/qb2js.exe
 qbjs.zip
 .vscode/launch.json
 .vscode/settings.json
+.vscode/tasks.json

--- a/codemirror/qb-lang.js
+++ b/codemirror/qb-lang.js
@@ -54,7 +54,7 @@ CodeMirror.defineMode("qbjs", function(conf, parserConf) {
                              'lbound', 'left', 'lcase', 'len', 'line', 'locate', 'log', 'ltrim', 'mid', 'mki', 'mkl',
                              'oct', 'paint', 'point', 'preset', 'print', 'pset',
                              'right', 'rtrim', 'randomize', 'read', 'restore', 'rnd',
-                             'screen', 'shared', 'sgn', 'sin', 'sleep', 'space', 'sqr',
+                             'screen', 'shared', 'sgn', 'sin', 'sleep', 'sound', 'space', 'sqr',
                              'str', 'swap', 'tan', 'time', 'timer', 'ubound', 'ucase',
                              'val', 'varptr', 'window',
                              'mkdir', 'chdir', 'rmdir', 'kill', 'name', 'files', 'open', 'close', 'lof', 'eof', 'put', 'get', 'freefile',

--- a/qb.js
+++ b/qb.js
@@ -2815,6 +2815,30 @@ var QB = new function() {
         }
     };
 
+    this.sub_Sound = async function(freq, duration, shape) {
+        if (shape == undefined) { shape = "square"; }
+        if (!(freq == 0 || (freq >= 32 && freq <= 32767))) {
+            throw new Error("Frequency invalid - valid: 0 (delay), 32 to 32767");
+        }
+        var valid_shapes = ["sine", "square", "sawtooth", "triangle"];
+        if (!valid_shapes.includes(shape.toLowerCase())) {
+            throw new Error("Shape invalid - valid: " + valid_shapes.join(', '));
+        }
+        if (freq == 0) {
+            await GX.sleep(duration);
+        } else {
+            var context = new AudioContext();
+            var oscillator = context.createOscillator();
+            oscillator.type = shape;
+            oscillator.frequency.value = freq;
+            oscillator.connect(context.destination);
+            oscillator.start(); 
+            setTimeout(await function () {
+                oscillator.stop();
+            }, duration);  
+        }
+    };
+
     this.func_Sqr = function(value) {
         return Math.sqrt(value);
     };

--- a/qb2js.js
+++ b/qb2js.js
@@ -3366,6 +3366,7 @@ if (QB.halted()) { return; }
    await sub_AddQBMethod( "FUNCTION" ,   "Sgn" ,    False);
    await sub_AddQBMethod( "FUNCTION" ,   "Sin" ,    False);
    await sub_AddQBMethod( "SUB" ,   "Sleep" ,    True);
+   await sub_AddQBMethod( "SUB" ,   "Sound" ,    True);
    await sub_AddQBMethod( "FUNCTION" ,   "Space" ,    False);
    await sub_AddQBMethod( "FUNCTION" ,   "String" ,    False);
    await sub_AddQBMethod( "FUNCTION" ,   "Sqr" ,    False);

--- a/tools/qb2js.bas
+++ b/tools/qb2js.bas
@@ -3581,6 +3581,7 @@ Sub InitQBMethods
     AddQBMethod "FUNCTION", "Sgn", False
     AddQBMethod "FUNCTION", "Sin", False
     AddQBMethod "SUB", "Sleep", True
+    AddQBMethod "SUB", "Sound", True
     AddQBMethod "FUNCTION", "Space", False
     AddQBMethod "FUNCTION", "String", False
     AddQBMethod "FUNCTION", "Sqr", False


### PR DESCRIPTION
Added SOUND keyword support with validation and support for additional shapes as provded by the [WebAudio API OscillatorNode](https://developer.mozilla.org/en-US/docs/Web/API/OscillatorNode) object.

Validation is based on legal QB SOUND ranges.

> Freq: `0` = Delay instead of sound, or `32` to `32767`
> Shape: default = `"square"` additional shapes: `"sine"`, `"sawtooth"`, `"triangle"`

Example code / test:
```basic
Sound 100, 100 : Sound 900, 100
Sound 100, 100 : Sound 0, 200 : Sound 800, 300
Sound 0, 500 : Sound 50, 50 : Sound 100, 50

Sound 0, 1000
Sound 800, 100, "triangle"
Sound 0, 500
Sound 1200, 100, "sawtooth"
Sound 2400, 200, "sine"

Sound 9000, 1000
Sound 9000, 1000, "triangle"
Sound 9000, 1000, "sawtooth"
Sound 9000, 1000, "sine"
```
