### PR TITLE
Added support for decay and gain

### DIFF
--- a/qb.js
+++ b/qb.js
@@ -2815,8 +2815,11 @@ var QB = new function() {
         }
     };
 
-    this.sub_Sound = async function(freq, duration, shape) {
+
+    this.sub_Sound = async function(freq, duration, shape, decay, gain) {
         if (shape == undefined) { shape = "square"; }
+        if (decay == undefined) { decay = 0.0; }
+        if (gain  == undefined) { gain = 1.0; }
         if (!(freq == 0 || (freq >= 32 && freq <= 32767))) {
             throw new Error("Frequency invalid - valid: 0 (delay), 32 to 32767");
         }
@@ -2829,12 +2832,16 @@ var QB = new function() {
         } else {
             var context = new AudioContext();
             var oscillator = context.createOscillator();
+            var gainNode = context.createGain();
             oscillator.type = shape;
             oscillator.frequency.value = freq;
-            oscillator.connect(context.destination);
+            oscillator.connect(gainNode);
+            gainNode.connect(context.destination)
+            gainNode.gain.value = gain;
             oscillator.start(); 
-            setTimeout(await function () {
-                oscillator.stop();
+            setTimeout(await async function () {
+                gainNode.gain.setTargetAtTime(0, context.currentTime, decay);
+                oscillator.stop(duration + decay + 1);
             }, duration);  
         }
     };

--- a/qb.js
+++ b/qb.js
@@ -2817,9 +2817,9 @@ var QB = new function() {
 
 
     this.sub_Sound = async function(freq, duration, shape, decay, gain) {
-        if (shape == undefined) { shape = "square"; }
-        if (decay == undefined) { decay = 0.0; }
-        if (gain  == undefined) { gain = 1.0; }
+        if (shape == undefined || (typeof shape != 'string')) { shape = "square"; }
+        if (decay == undefined || (typeof decay != 'number')) { decay = 0.0; }
+        if (gain  == undefined || (typeof gain != 'number')) { gain = 1.0; }
         if (!(freq == 0 || (freq >= 32 && freq <= 32767))) {
             throw new Error("Frequency invalid - valid: 0 (delay), 32 to 32767");
         }


### PR DESCRIPTION
I added support for decay and gain.

Example code:
```basic
sound 500, 1500, "sine", 0.5, 1
sound 0, 2000
sound 1500, 1500, "sine", 0.5, 0.1
sound 0, 2000
sound 2500, 1000, "sine", 0.25, 0.05
sound 0, 2000
sound 500, 1500, "sawtooth", 0.5, 0.3
sound 0, 2000
sound 1500, 1500, "square", 0.5, 0.1
sound 0, 2000
sound 2500, 1000, "triangle", 0.25, 0.05
sound 3000, 1000
sound 0, 4000
sound 900, 400, "square", 0, 1
sound 0, 500
sound 900, 400
```

Default gain: 1
Default decay: 0
