### PR TITLE
Allows CLOSE to be called without parameters

### DIFF
--- a/qb.js
+++ b/qb.js
@@ -1064,6 +1064,11 @@ var QB = new function() {
     };
 
     this.sub_Close = function(fh) {
+        if (!fh) {
+            _fileHandles.length = 0; //must be rethought once FREEFILE gets implemented.
+            return;
+        }
+        
         if (!_fileHandles[fh]) {
             throw new Error("Invalid file handle");
         }


### PR DESCRIPTION
CLOSE should invalidate all open handles when called with no parameters;

While setting `.length = 0` might not be the best approach here, it should work.

This will need to be rethought anyway when FREEFILE is implemented.