### PR TITLE
Adds a space after a number is printed.

### DIFF
--- a/qb.js
+++ b/qb.js
@@ -2799,6 +2799,7 @@ var QB = new function() {
                     if (str >= 0) {
                         str = " " + str;
                     }
+                    str = str + " "; //a space is added to the end numbers when printing
                 }
                 var lines = String(str).split("\n");
                 for (var i=0; i < lines.length; i++) {


### PR DESCRIPTION
Research into `qb64pe.bas` reveals that the logic is just this: if not a string, then add a space

Keeps compatibility and fixes #84